### PR TITLE
Fix several spelling/indentation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ DoCIF was originally made for [RoboJackets/robocup-software](https://www.github.
 * Git managed project and `git 2.0+`
 * [Docker](https://www.docker.com) installed on your system or continuous integration
 * Bash on a POSIX (preferrably GNU) system.
-* CircleCi Continuous Integration. The features included in DoCIF take adavantage of it's features, such as artifact deployment, and caching.
+* CircleCi Continuous Integration. The features included in DoCIF take adavantage of its features, such as artifact deployment, and caching.
 
 ## Setup
 Setup of DoCIF is designed to be easy, assuming you know how to set up your project on a linux machine!

--- a/commands/Dockerfile
+++ b/commands/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER Jay Kamat github@jgkamat.33mail.com
 ENV DEBIAN_FRONTEND noninteractive
 
 # Use UTF-8, fixes some hard to debug issues
-# This is not workin on cirlceci's current setup. Will reenable once its working again
+# This is not workin on cirlceci's current setup. Will reenable once it's working again
 # RUN locale-gen en_US.UTF-8
 # ENV LANG en_US.UTF-8
 

--- a/config.docif
+++ b/config.docif
@@ -1,10 +1,10 @@
 #!/bin/bash
 #
 # THIS IS NOT A SAMPLE CONFIG.DOCIF
-# THIS FILES IS UESED BY DOCIF'S CONTINUOUS INTEGRATION.
+# THIS FILE IS USED BY DOCIF'S CONTINUOUS INTEGRATION.
 
 # @REQUIRED
-# A docker baseimage repostiory. Create one on the docker hub
+# A docker baseimage repository. Create one on the docker hub
 BASEIMAGE_REPO="jgkamat/testdocif-baseimage"
 
 # If true, ${BASEIMAGE_REPO}:master is pushed when on master.
@@ -12,7 +12,7 @@ BASEIMAGE_REPO="jgkamat/testdocif-baseimage"
 PUSH_BASEIMAGE="true"
 
 # @REQUIRED
-# The github repository location, for sendings status updates to
+# The github repository location, for sending status updates to
 # This is CASE SENSITIVE!!
 GITHUB_REPO='jgkamat/DoCIF'
 
@@ -47,7 +47,7 @@ GH_EMAIL_VAR="GH_EMAIL"
 
 
 # The project root INSIDE THE DOCKER CONTAINER
-# Reccomended to leave as default (not set)
+# Recommended to leave as default (not set)
 # This will act as the 'current directory' within the project
 # This will need to be changed in the dockerfile as well to take effect. (use a custom one!)
 # DOCKER_PROJECT_ROOT="/home/developer/project"
@@ -69,7 +69,7 @@ CACHE_DIRECTORIES+=('~/.ccache')
 ################################# COMMANDS #####################################
 
 # The script to set up the environment, by default ubuntu.
-# YOU WILL NEED TO USE SUDO TO GET ROOT PRIVLEGES HERE
+# YOU WILL NEED TO USE SUDO TO GET ROOT PRIVILEGES HERE
 SETUP_COMMAND="sudo apt-get update && sudo apt-get -y install htop"
 # SETUP_COMMAND="./ubuntu-setup-script"
 
@@ -83,7 +83,7 @@ SETUP_SHA_FILES+=("./config.docif")
 SETUP_SHA_FILES+=("./.testing/docif.rev")
 
 # @REQUIRED
-# Commands to run when testing. Each index will have it's own status token
+# Commands to run when testing. Each index will have its own status token
 # Commands are in this format
 # COMMAND; SHORT_NAME; DESCRIPTION
 TEST_COMMANDS=()
@@ -93,7 +93,7 @@ TEST_COMMANDS+=( 'true && [ "root" = "`whoami`" ];test-complex;Test if we can ha
 TEST_COMMANDS+=( '[ -n "$TEST_ENV_VARS" ];test-external-vars;Test if external variables make it into the container' )
 TEST_COMMANDS+=( 'cd /bin && [ -e bash ];test-cd-dir;Test if a cd command works' )
 
-# @RECCOMENDED
+# @RECOMMENDED
 # Clean command. Cleans the build files so there is no way the previous build can interfere. Add if you run
 # into issues
 CLEAN_COMMAND="true"

--- a/sample/circle.yml
+++ b/sample/circle.yml
@@ -19,7 +19,7 @@ checkout:
 
 dependencies:
   pre:
-      # set build status to pending on start
+      # Set build status to pending on start
     - ./DoCIF/util/maketest.sh --pending
     - ./DoCIF/commands/buildbaseimage.sh
       # Actually the test step, but we want to cache it so it can go here.

--- a/sample/sample_config.docif
+++ b/sample/sample_config.docif
@@ -13,7 +13,7 @@ BASEIMAGE_REPO="jgkamat/vipaint-baseimage"
 PUSH_BASEIMAGE="true"
 
 # @REQUIRED
-# The github repository location, for sendings status updates to
+# The github repository location, for sending status updates to
 # This is CASE SENSITIVE!!
 GITHUB_REPO='jgkamat/ViPaint'
 
@@ -48,7 +48,7 @@ GH_EMAIL_VAR="GH_EMAIL"
 
 
 # The project root INSIDE THE DOCKER CONTAINER
-# Reccomended to leave as default (not set)
+# Recommended to leave as default (not set)
 # This will act as the 'current directory' within the project
 # This will need to be changed in the dockerfile as well to take effect. (use a custom one!)
 # DOCKER_PROJECT_ROOT="/root/project"
@@ -73,7 +73,7 @@ CACHE_DIRECTORIES+=('~/.ccache')
 ################################# COMMANDS #####################################
 
 # The script to set up the environment, by default ubuntu.
-# YOU WILL NEED TO USE SUDO TO GET ROOT PRIVLEGES HERE
+# YOU WILL NEED TO USE SUDO TO GET ROOT PRIVILEGES HERE
 SETUP_COMMAND="sudo apt-get update && sudo apt-get -y install emacs"
 # SETUP_COMMAND="./ubuntu-setup-script"
 
@@ -86,7 +86,7 @@ SETUP_SHA_FILES+=("./.gitmodules")
 SETUP_SHA_FILES+=("./sample-config.docif")
 
 # @REQUIRED
-# Commands to run when testing. Each index will have it's own status token
+# Commands to run when testing. Each index will have its own status token
 # Commands are in this format
 # COMMAND; SHORT_NAME; DESCRIPTION
 TEST_COMMANDS=()

--- a/util/maketest.sh
+++ b/util/maketest.sh
@@ -24,9 +24,9 @@ start_pending() {
 
 	SHORTNAME="$1"
 	>/dev/null curl -s -u $GH_USERNAME:$GH_STATUS_TOKEN \
-	 -X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
-	 -H "Content-Type: application/json" \
-	 -d '{"state":"pending", "description": "This check is pending. Please wait.", "context": '"\"circle/$SHORTNAME\""', "target_url": "'"${PENDING_URL}"'"}'
+		-X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
+		-H "Content-Type: application/json" \
+		-d '{"state":"pending", "description": "This check is pending. Please wait.", "context": '"\"circle/$SHORTNAME\""', "target_url": "'"${PENDING_URL}"'"}'
 }
 
 fail_test() {
@@ -37,9 +37,9 @@ fail_test() {
 
 	SHORTNAME="$1"
 	>/dev/null curl -s -u $GH_USERNAME:$GH_STATUS_TOKEN \
-	 -X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
-	 -H "Content-Type: application/json" \
-	 -d '{"state":"failure", "description": "This check failed due to an internal error.", "context": '"\"circle/$SHORTNAME\""', "target_url": "'"${PENDING_URL}"'"}'
+		-X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
+		-H "Content-Type: application/json" \
+		-d '{"state":"failure", "description": "This check failed due to an internal error.", "context": '"\"circle/$SHORTNAME\""', "target_url": "'"${PENDING_URL}"'"}'
 }
 
 # A function to run a command. Takes in a command name, shortname and description.
@@ -65,14 +65,14 @@ ci_task() {
 
 	if [ "${CMD_STATUS}" = "0" ]; then
 		>/dev/null curl -s -u $GH_USERNAME:$GH_STATUS_TOKEN \
-		 -X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
-		 -H "Content-Type: application/json" \
-		 -d '{"state":"success", "description": '"\"${DESCRIPTION}\""', "context": '"\"circle/${SHORTNAME}\""', "target_url": '""\"${LINK_PREFIX}${SHORTNAME}.txt\""}"
+			-X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
+			-H "Content-Type: application/json" \
+			-d '{"state":"success", "description": '"\"${DESCRIPTION}\""', "context": '"\"circle/${SHORTNAME}\""', "target_url": '""\"${LINK_PREFIX}${SHORTNAME}.txt\""}"
 	else
 		>/dev/null curl -s -u $GH_USERNAME:$GH_STATUS_TOKEN \
-		 -X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
-		 -H "Content-Type: application/json" \
-		 -d '{"state":"failure", "description": '"\"${DESCRIPTION}\""', "context": '"\"circle/${SHORTNAME}\""', "target_url": '""\"${LINK_PREFIX}${SHORTNAME}.txt\""}"
+			-X POST https://api.github.com/repos/${GITHUB_REPO}/statuses/${COMMIT_SHA} \
+			-H "Content-Type: application/json" \
+			-d '{"state":"failure", "description": '"\"${DESCRIPTION}\""', "context": '"\"circle/${SHORTNAME}\""', "target_url": '""\"${LINK_PREFIX}${SHORTNAME}.txt\""}"
 		SUCCESS=false
 	fi
 }


### PR DESCRIPTION
What it says on the tin: a bunch of spelling/indentation fixes.

I originally went through the master branch, fixing way more spelling/indentation errors, but it seems you've already fixed some in the beta branch. The most common fixes:
- misspelling words like "recommended" 
- mixing up "it's" and "its"

I held off on capitalization fixes (e.g. "github" -> "GitHub", "dockerfile" -> "Dockerfile", "circleci" -> "CircleCI") for now, but they could be fixed pretty easily as well.
